### PR TITLE
Don't add the score of a sheet multiple times

### DIFF
--- a/netsecus/webhandler/StudentHandler.py
+++ b/netsecus/webhandler/StudentHandler.py
@@ -19,7 +19,8 @@ class StudentHandler(NetsecHandler):
 
         submission_with_score = []
         student_total_score = 0
-
+        added_sheets = set()
+        
         for subm in fs.submissions:
             student_score = 0
 
@@ -34,7 +35,10 @@ class StudentHandler(NetsecHandler):
                         "student_score": student_score,
                         "total_score": total_score,
                     })
-                    student_total_score += student_score
+                    
+                    if subm.sheet_id not in added_sheets:
+                        student_total_score += student_score
+                        added_sheets.add(subm.sheet_id)
                     break
 
         self.render('student', {

--- a/netsecus/webhandler/StudentHandler.py
+++ b/netsecus/webhandler/StudentHandler.py
@@ -20,7 +20,7 @@ class StudentHandler(NetsecHandler):
         submission_with_score = []
         student_total_score = 0
         added_sheets = set()
-        
+
         for subm in fs.submissions:
             student_score = 0
 
@@ -35,7 +35,7 @@ class StudentHandler(NetsecHandler):
                         "student_score": student_score,
                         "total_score": total_score,
                     })
-                    
+
                     if subm.sheet_id not in added_sheets:
                         student_total_score += student_score
                         added_sheets.add(subm.sheet_id)


### PR DESCRIPTION
By now if a student has multiple submissions for the same sheet, the score of this sheet will be added multiple times to the total score of the student, resulting in a wrong total score and percentage.

The submission will still be added to the submissions list to show, that the user has made multiple submissons. 

Please review as I didn't test this.